### PR TITLE
fix error in "terraform init" with Terraform v1.1.1

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -42,7 +42,7 @@ resource "aws_lambda_function" "power-of-number-lambda" {
   function_name    = "step-functions-sample-power-of-number"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "index.handler"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs14.x"
 }
 
 resource "aws_lambda_function" "random-number-generator-lambda" {
@@ -50,5 +50,5 @@ resource "aws_lambda_function" "random-number-generator-lambda" {
   function_name    = "step-functions-sample-random-number-generator"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "index.handler"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs14.x"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,17 +1,17 @@
 variable "aws_region" {
-  type = "string"
+  type = string
   description = "Specified AWS Region"
   default = "ap-southeast-1"
 }
 
 variable "aws_credential_profile" {
-  type = "string"
+  type = string
   description = "AWS Profile With Admin Access"
   default = ""
 }
 
 variable "phone_number_for_notification" {
-  type = "string"
+  type = string
   description = "Valid Handphone number for notification"
   default = ""
 }


### PR DESCRIPTION
Terraform 0.11 and earlier required type constraints to be given in quotes, but that form is now deprecated
│ and will be removed in a future version of Terraform. Remove the quotes around "string".